### PR TITLE
feat: Add Docker and docker-compose.yml

### DIFF
--- a/apps/api/build.gradle.kts
+++ b/apps/api/build.gradle.kts
@@ -25,11 +25,11 @@ dependencies {
 	// Liquibase for database migrations
 	runtimeOnly(local.liquibase.core)
 
-	// H2 in-memory database
-	runtimeOnly(local.h2database)
-
 	// R2DBC driver for reactive database access for H2
-	runtimeOnly(local.r2dbch2)
+	runtimeOnly(local.r2dbc.h2)
+
+	// R2DBC driver for reactive database access for PostgreSQL
+	runtimeOnly(local.r2dbc.postgres)
 
 	// FasterXML Jackson module for Kotlin support
 	implementation(local.jackson.module.kotlin)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+services:
+  postgres:
+    image: postgres:17
+    container_name: postgres
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: sample-db
+    ports:
+      - "5432:5432"
+    restart: unless-stopped
+  api:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile
+    container_name: spring-webflux-kotlin-reactive-api
+    depends_on:
+      - postgres
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/sample-db
+      SPRING_DATASOURCE_USERNAME: postgres
+      SPRING_DATASOURCE_PASSWORD: postgres
+    image: spring-webflux-kotlin-reactive:latest
+    ports:
+      - "8080:8080"
+    restart: unless-stopped

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,33 @@
+# Stage 1: Build the application using a Gradle image with JDK 21.
+FROM gradle:8.13.0-jdk21-corretto AS builder
+WORKDIR /home/gradle/project
+
+# Copy Gradle files from the correct locations.
+COPY gradlew gradlew.bat ./
+COPY gradle/wrapper/ gradle/wrapper/
+COPY gradle/local.versions.toml gradle/
+COPY settings.gradle.kts ./
+COPY build.gradle.kts ./
+
+# Make gradlew executable.
+RUN chmod +x gradlew
+
+# Download dependencies (this layer will be cached unless build files change).
+RUN ./gradlew --no-daemon dependencies
+
+# Copy the rest of the source code.
+COPY . .
+
+# Build the api subproject.
+# Exclude tests to speed up the build.
+RUN ./gradlew --no-daemon :api:clean :api:build -x test
+
+# Stage 2: Package the application into a runtime image using temurin JDK 21.
+FROM eclipse-temurin:21-jdk
+WORKDIR /app
+
+# Copy the generated jar from the builder stage.
+COPY --from=builder /home/gradle/project/apps/api/build/libs/api.jar app.jar
+
+# Run the application.
+CMD ["java", "-jar", "app.jar"]

--- a/gradle/local.versions.toml
+++ b/gradle/local.versions.toml
@@ -1,16 +1,36 @@
 [versions]
 coroutines = "1.10.1"
-h2database = "2.3.232"
 jackson = "2.18.3"
 junitPlatformLauncher = "1.11.4"
 kotlin = "2.1.10"
 liquibase = "4.31.1"
+r2dbcH2 = "1.0.0.RELEASE"
+r2dbcPostgres = "1.0.7.RELEASE"
 springboot = "3.4.3"
 springDependencyPlugin = "1.1.6"
 springdoc = "2.8.5"
-r2dbc-h2 = "1.0.0.RELEASE"
 
 [libraries]
+# FasterXML Jackson module for Kotlin support
+jackson-module-kotlin = { module = "com.fasterxml.jackson.module:jackson-module-kotlin", version.ref = "jackson" }
+
+# Test libraries
+junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junitPlatformLauncher" }
+kotlin-test-junit5 = { module = "org.jetbrains.kotlin:kotlin-test-junit5", version.ref = "kotlin" }
+
+# Kotlin Coroutines
+kotlin-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
+kotlin-coroutines-reactor = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-reactor", version.ref = "coroutines" }
+kotlin-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
+
+# Liquibase for managing database changelogs
+liquibase-core = { module = "org.liquibase:liquibase-core", version.ref = "liquibase" }
+
+# R2DBC driver for reactive database access for H2
+r2dbc-h2 = { module = "io.r2dbc:r2dbc-h2", version.ref = "r2dbcH2" }
+
+# R2DBC driver for reactive database access for PostgreSQL
+r2dbc-postgres = { module = "org.postgresql:r2dbc-postgresql", version.ref = "r2dbcPostgres" }
 
 # Spring Boot libraries
 springboot-starter = { module = "org.springframework.boot:spring-boot-starter", version.ref = "springboot" }
@@ -18,29 +38,8 @@ springboot-starter-r2dbc = { module = "org.springframework.boot:spring-boot-star
 springboot-starter-test = { module = "org.springframework.boot:spring-boot-starter-test", version.ref = "springboot" }
 springboot-starter-webflux = { module = "org.springframework.boot:spring-boot-starter-webflux", version.ref = "springboot" }
 
-# Kotlin Coroutines
-kotlin-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
-kotlin-coroutines-reactor = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-reactor", version.ref = "coroutines" }
-kotlin-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
-
 # Springdoc provides swagger docs with support for Spring Web MVC
 springdoc-openapi-starter-webflux = { module = "org.springdoc:springdoc-openapi-starter-webflux-ui", version.ref = "springdoc" }
-
-# R2DBC driver for reactive database access for H2
-r2dbch2 = { module = "io.r2dbc:r2dbc-h2", version.ref = "r2dbc-h2" }
-
-# H2 for in-memory database
-h2database = { module = "com.h2database:h2", version.ref = "h2database" }
-
-# Liquibase for managing database changelogs
-liquibase-core = { module = "org.liquibase:liquibase-core", version.ref = "liquibase" }
-
-# FasterXML Jackson module for Kotlin support
-jackson-module-kotlin = { module = "com.fasterxml.jackson.module:jackson-module-kotlin", version.ref = "jackson" }
-
-# Test libraries
-junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junitPlatformLauncher" }
-kotlin-test-junit5 = { module = "org.jetbrains.kotlin:kotlin-test-junit5", version.ref = "kotlin" }
 
 [plugins]
 springboot = { id = "org.springframework.boot", version.ref = "springboot" }


### PR DESCRIPTION
- Add `Dockerfile` which will build a runnable docker image for the `api` subproject.
- Add PostgreSQL Gradle dependency.
- Update `application.yml` to include environment variables for the datasource. The default values will be for the H2 in-memory database but you can configure these environment variables to connect to a PostgreSQL database instead.
- Add `docker-compose.yml` which will run a PostgreSQL image and build the Spring Boot instance from the `Dockerfile` and run everything together. 
- Remove unnecessary Gradle dependency `com.h2database:h2`. We are using `io.r2dbc:r2dbc-h2` as driver so we don't need `com.h2database:h2`.

This allows you to run the entire project with a PostgreSQL database using:
```
docker compose up -d
```