### PR TITLE
fix: Docker compose not working as expected

### DIFF
--- a/apps/api/build.gradle.kts
+++ b/apps/api/build.gradle.kts
@@ -31,6 +31,12 @@ dependencies {
 	// R2DBC driver for reactive database access for PostgreSQL
 	runtimeOnly(local.r2dbc.postgres)
 
+	// H2 in-memory database driver for Liquibase
+	runtimeOnly(local.h2database)
+
+	// PostgreSQL database driver for Liquibase
+	runtimeOnly(local.postgres)
+
 	// FasterXML Jackson module for Kotlin support
 	implementation(local.jackson.module.kotlin)
 

--- a/apps/api/src/main/resources/application.yml
+++ b/apps/api/src/main/resources/application.yml
@@ -1,14 +1,15 @@
 spring:
   r2dbc:
-    url: r2dbc:h2:mem:///testdb;DB_CLOSE_DELAY=-1;MODE=PostgreSQL
-    username: sa
-    password:
+    # Use the environment variable R2DBC_URL if provided, otherwise default to H2
+    url: ${R2DBC_URL:r2dbc:h2:mem:///testdb;DB_CLOSE_DELAY=-1;MODE=PostgreSQL}
+    username: ${R2DBC_USERNAME:sa}
+    password: ${R2DBC_PASSWORD:}
   liquibase:
     enabled: true
     # Note that we use jdbc for Liquibase and r2dbc for the application
-    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MODE=PostgreSQL
-    user: sa
-    password:
+    url: ${LIQUIBASE_URL:jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MODE=PostgreSQL}
+    user: ${LIQUIBASE_USER:sa}
+    password: ${LIQUIBASE_PASSWORD:}
 springdoc:
   api-docs:
     enabled: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,9 +17,12 @@ services:
     depends_on:
       - postgres
     environment:
-      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/sample-db
-      SPRING_DATASOURCE_USERNAME: postgres
-      SPRING_DATASOURCE_PASSWORD: postgres
+      R2DBC_URL: r2dbc:postgresql://postgres:5432/sample-db
+      R2DBC_USERNAME: postgres
+      R2DBC_PASSWORD: postgres
+      LIQUIBASE_URL: jdbc:postgresql://postgres:5432/sample-db
+      LIQUIBASE_USER: postgres
+      LIQUIBASE_PASSWORD: postgres
     image: spring-webflux-kotlin-reactive:latest
     ports:
       - "8080:8080"

--- a/gradle/local.versions.toml
+++ b/gradle/local.versions.toml
@@ -1,9 +1,11 @@
 [versions]
 coroutines = "1.10.1"
+h2database = "2.3.232"
 jackson = "2.18.3"
 junitPlatformLauncher = "1.11.4"
 kotlin = "2.1.10"
 liquibase = "4.31.1"
+postgres = "42.7.5"
 r2dbcH2 = "1.0.0.RELEASE"
 r2dbcPostgres = "1.0.7.RELEASE"
 springboot = "3.4.3"
@@ -11,6 +13,9 @@ springDependencyPlugin = "1.1.6"
 springdoc = "2.8.5"
 
 [libraries]
+# H2 for in-memory database
+h2database = { module = "com.h2database:h2", version.ref = "h2database" }
+
 # FasterXML Jackson module for Kotlin support
 jackson-module-kotlin = { module = "com.fasterxml.jackson.module:jackson-module-kotlin", version.ref = "jackson" }
 
@@ -25,6 +30,9 @@ kotlin-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-te
 
 # Liquibase for managing database changelogs
 liquibase-core = { module = "org.liquibase:liquibase-core", version.ref = "liquibase" }
+
+# PostgreSQL for live database
+postgres = { module = "org.postgresql:postgresql", version.ref = "postgres" }
 
 # R2DBC driver for reactive database access for H2
 r2dbc-h2 = { module = "io.r2dbc:r2dbc-h2", version.ref = "r2dbcH2" }


### PR DESCRIPTION
- Add environment variables to `application.yml` which `docker-compose.yml` can override to use PostgreSQL instead of H2.
- Add JDBC database drivers for H2 and PostgreSQL as this is needed for Liquibase.