### PR TITLE
feat: Use Testcontainers for controller tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,17 @@ to view the Swagger documentation.
 - [H2database](https://github.com/h2database/h2database) - Provides an in-memory database for simple local testing
 - [R2DBC-H2](https://github.com/r2dbc/r2dbc-h2) - R2DBC driver for H2 database
 - [Liquibase](https://github.com/liquibase/liquibase) - Used to manage database schema changelogs
+- [Testcontainers](https://github.com/testcontainers) - Creates a temporary PostgreSQL database for tests
+
+## Testing
+You can run the tests for this project using the following command:
+```
+./gradlew test
+```
+Please note that this project uses
+[Testcontainers](https://github.com/testcontainers)
+to create a temporary PostgreSQL database for tests. This requires
+a local Docker instance to be running when executing the tests.
 
 ## Gradle best practices for Kotlin
 [kotlinlang.org](https://kotlinlang.org/docs/gradle-best-practices.html)

--- a/apps/api/build.gradle.kts
+++ b/apps/api/build.gradle.kts
@@ -42,6 +42,9 @@ dependencies {
 
 	// Test dependencies
 	testImplementation(local.springboot.starter.test)
+	testImplementation(local.springboot.testcontainers)
+	testImplementation(local.testcontainers.postgresql)
+	testImplementation(local.testcontainers.r2dbc)
 	testImplementation(local.kotlin.test.junit5)
 	testRuntimeOnly(local.junit.platform.launcher)
 }

--- a/apps/api/src/main/resources/application-postgres.yml
+++ b/apps/api/src/main/resources/application-postgres.yml
@@ -1,0 +1,11 @@
+spring:
+  r2dbc:
+    url: r2dbc:postgresql://postgres:5432/sample-db
+    username: postgres
+    password: postgres
+  liquibase:
+    enabled: true
+    # Note that we use jdbc for Liquibase and r2dbc for the application
+    url: jdbc:postgresql://postgres:5432/sample-db
+    user: postgres
+    password: postgres

--- a/apps/api/src/test/kotlin/com/github/thorlauridsen/CustomerControllerTest.kt
+++ b/apps/api/src/test/kotlin/com/github/thorlauridsen/CustomerControllerTest.kt
@@ -12,15 +12,20 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Import
+import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.reactive.server.WebTestClient
 
 /**
  * Test class for testing the CustomerController.
  * The test methods use [WebTestClient] to make requests to the controller endpoints.
  * [WebTestClient] has support for testing reactive web applications (Spring Boot Webflux).
+ * A local Docker instance is required to run the tests as Testcontainers is used.
  */
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("postgres")
 @AutoConfigureWebTestClient
+@Import(TestContainerConfig::class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class CustomerControllerTest(
     @Autowired private val client: WebTestClient
 ) {

--- a/apps/api/src/test/kotlin/com/github/thorlauridsen/TestContainerConfig.kt
+++ b/apps/api/src/test/kotlin/com/github/thorlauridsen/TestContainerConfig.kt
@@ -1,0 +1,25 @@
+package com.github.thorlauridsen
+
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection
+import org.springframework.context.annotation.Bean
+import org.testcontainers.containers.PostgreSQLContainer
+
+@TestConfiguration(proxyBeanMethods = false)
+class TestContainerConfig {
+
+    /**
+     * A [PostgreSQLContainer] bean to be used in tests.
+     * This uses Testcontainers to spin up a temporary PostgreSQL instance in a Docker container.
+     * The [ServiceConnection] annotation allows Spring Boot to automatically
+     * configure the datasource properties based on the container settings.
+     */
+    @Bean
+    @ServiceConnection // lets Spring Boot wire spring.datasource.* automatically
+    fun postgresContainer(): PostgreSQLContainer<*> {
+        return PostgreSQLContainer("postgres:17")
+            .withDatabaseName("sample-db")
+            .withUsername("postgres")
+            .withPassword("postgres")
+    }
+}

--- a/gradle/local.versions.toml
+++ b/gradle/local.versions.toml
@@ -11,6 +11,7 @@ r2dbcPostgres = "1.0.7.RELEASE"
 springboot = "3.5.5"
 springDependencyPlugin = "1.1.7"
 springdoc = "2.8.11"
+testcontainers = "1.21.3"
 
 [libraries]
 # H2 for in-memory database
@@ -45,6 +46,11 @@ springboot-starter = { module = "org.springframework.boot:spring-boot-starter", 
 springboot-starter-r2dbc = { module = "org.springframework.boot:spring-boot-starter-data-r2dbc", version.ref = "springboot" }
 springboot-starter-test = { module = "org.springframework.boot:spring-boot-starter-test", version.ref = "springboot" }
 springboot-starter-webflux = { module = "org.springframework.boot:spring-boot-starter-webflux", version.ref = "springboot" }
+springboot-testcontainers = { module = "org.springframework.boot:spring-boot-testcontainers", version.ref = "springboot" }
+
+# Testcontainers for running PostgreSQL in tests
+testcontainers-postgresql = { module = "org.testcontainers:postgresql", version.ref = "testcontainers" }
+testcontainers-r2dbc = { module = "org.testcontainers:r2dbc", version.ref = "testcontainers" }
 
 # Springdoc provides swagger docs with support for Spring Web MVC
 springdoc-openapi-starter-webflux = { module = "org.springdoc:springdoc-openapi-starter-webflux-ui", version.ref = "springdoc" }


### PR DESCRIPTION
[Testcontainers](https://github.com/testcontainers) allow us to spin up a temporary Docker image during tests. For this project, we will spin up a temporary PostgreSQL database to run the controller tests against a real PostgreSQL database instead of an in-memory H2 database. There are differences between PostgreSQL and H2 databases so if you plan to use a PostgreSQL database in production, it also makes sense to mimic this by using a PostgreSQL database in the tests. H2 databases are useful for quickly testing and running the system locally, but it is better to use Testcontainers to run a real PostgreSQL database for the controller tests.

Use Testcontainers for controller tests:
- Add Gradle dependencies to `local.versions.toml` and `api/build.gradle.kts`:
  - `org.springframework.boot:spring-boot-testcontainers`
  - `org.testcontainers:postgresql`
  - `org.testcontainers:r2dbc`
- Add `TestContainerConfig` which defines the PostgreSQL container and database settings.
- Add annotations `@Import(TestContainerConfig::class)` and `@ActiveProfiles("postgres")` to `CustomerControllerTest` to ensure that a PostgreSQL database is used for the tests.
- Add `application-postgres.yml` with connection settings for PostgreSQL.
- Update `README.md`.