### PR TITLE
build: Use Kotlin DSL accessors in build.gradle.kts files

### DIFF
--- a/apps/api/build.gradle.kts
+++ b/apps/api/build.gradle.kts
@@ -49,6 +49,6 @@ dependencies {
 	testRuntimeOnly(local.junit.platform.launcher)
 }
 
-tasks.withType<Test> {
+tasks.test {
 	useJUnitPlatform()
 }

--- a/modules/persistence/build.gradle.kts
+++ b/modules/persistence/build.gradle.kts
@@ -1,6 +1,3 @@
-import org.springframework.boot.gradle.tasks.bundling.BootJar
-import org.springframework.boot.gradle.tasks.run.BootRun
-
 plugins {
     kotlin("plugin.spring") version local.versions.kotlin
     alias(local.plugins.springboot)
@@ -12,14 +9,14 @@ dependencies {
     implementation(projects.model)
 
     // Spring Data R2DBC for reactive SQL database access
-	implementation(local.springboot.starter.r2dbc)
+    implementation(local.springboot.starter.r2dbc)
 }
 
 // Disabling bootJar and bootRun is necessary for a subproject/module
 // that uses the Spring Boot plugin but is not supposed to be executable.
-tasks.named<BootJar>("bootJar") {
+tasks.bootJar {
     enabled = false
 }
-tasks.named<BootRun>("bootRun") {
+tasks.bootRun {
     enabled = false
 }


### PR DESCRIPTION
Take advantage of the features of Kotlin DSL by using accessors in `build.gradle.kts` files.